### PR TITLE
feat: Move the ethereum/L2-interop standarization effort to ERC-7828

### DIFF
--- a/ERCS/erc-7828.md
+++ b/ERCS/erc-7828.md
@@ -1,236 +1,465 @@
 ---
 eip: 7828
-title: Chain-specific addresses using ENS
-description: A unified chain-specific address format that allows specifying the account as well as the chain on which that account intends to transact.
-author: Sam Kaufman (@SampkaML), Marco Stronati (@paracetamolo), Yuliya Alexiev (@yuliyaalexiev), Jeff Lau (@jefflau), Sam Wilson (@samwilsn), Vitalik Buterin (@vbuterin)
+title: Interoperable Addresses
+description: An extensible binary format to describe an address specific to one chain which also includes the information to securely condense it into a human-readable name.
+author: Sam Kaufman (@SampkaML), Marco Stronati (@paracetamolo), Yuliya Alexiev (@yuliyaalexiev), Jeff Lau (@jefflau), Sam Wilson (@samwilsn), Vitalik Buterin (@vbuterin), Teddy (@0xteddybear), Joxes (@0xJoxess)
 discussions-to: https://ethereum-magicians.org/t/erc-7828-chain-specific-addresses-using-ens/21930
 status: Draft
 type: Standards Track
 category: ERC
 created: 2024-11-27
-requires: 55, 137, 155, 7785
+requires: CAIP-2 ENSIP-11 
 ---
 
 ## Abstract
-
-This proposal builds off of [ERC-7785](./eip-7785.md) (on-chain configs) to provide a standard and human-readable format for chain-specific L2 addresses:
-- A unified format for accounts that specifies, together with the address, the chain where the address lives.
-- The use of human-readable chain names and how they can be resolved to chain identifiers using ENS on L1.
-- The use of human-readable account names and how they can be resolved to addresses using ENS on L2.
+An extensible binary format to describe an address specific to one chain which also includes the information to securely condense it into a human-readable name.
 
 ## Motivation
 
-The current Ethereum address landscape is leading to an ecosystem that will have hundreds and eventually thousands of L2s that use the same address format as Ethereum mainnet. This means an address by itself is not enough information to know which chain the address is related to. This can be problematic if funds are sent to an unreachable address on the incorrect chain. From the user account it should be possible to obtain the right chain identifier (chainID) to include in a transaction. 
+The Ethereum ecosystem is rapidly expanding into a multi-chain environment encompassing L1s, L2s, sidechains, and rollups—some EVM‐compatible, others not. A simple address alone no longer identifies which chain the address belongs to, creating ambiguity for wallets, dApps, and users. At the same time, human‐readable naming (e.g. ENS) is important for usability, but must be deterministically tied to the correct network.
 
-The mapping from chain names to identifiers has, since [EIP-155](./eip-155.md), been maintained off chain using a centralized list. This solution has two main shortcomings:
- - It does not scale with the growing number of L2s.
- - The list maintainer is a trusted centralized entity.
+Interoperable Addresses build on insights from previous iterations of this standard and related discussions, offering a unified format which combines:
+- Binding chain specificity (via explicit chain identifiers) to the raw address,
+- Support for human‐readable naming (through optional resolvers, e.g., ENS), and
+- Checksums for name collision mitigation.
 
-Instead of using chain identifiers, which are not human readable, the address could be extended with a human-readable chain name, which can then be resolved to a chain identifier.
-The mapping from chain names to identifiers can be resolved off-chain using existing centralized lists or on-chain using ENS (see ERC-7785).
+All without adding new trust assumptions beyond what wallets already apply. By bundling chain references, addresses, and optional resolver info into a canonical binary format, wallets can deterministically parse and display addresses, while users benefit from intuitive names.
+In short, this standard aims to:
+- Erase ambiguity by enshrining a deterministic link between chain and address.
+- Remain resolution‐agnostic, supporting various naming services and chain registries.
+- Permit multiple “version” specifications, ensuring future extensibility for different resolution schemes.
+- Provide a stable, machine‐readable binary representation digestible by smart contracts.
 
-In the same spirit, the address could be a human-readable name as well, which is already a use case for ENS. However it would be desirable if the address name could be registered on a L2.
+These goals make Interoperable Addresses future-proof and user-friendly, enabling trustless, cross-chain workflows in a multi-chain world. The format also seeks to align with existing standards (e.g., CAIP-2, CAIP-10) and embrace diversity of identifier formats.
 
-Desired properties:
-- a unified format to represent any address on L1 or L2
-- the ability to use chain names in addition to identifiers
-- the chain portion can be a domain name, or just the suffix for a "base chain" (eg. `eth`, `myfavoriterollup.eth`, `sepolia`, `my_l3.base.superchain.eth`)
-- the address portion can be either the appropriate type of address for the chain (0x... for EVM chains, otherwise eg. for starknet something else), or a domain name (ENS or other)
-- the ability to resolve ENS names on the L2
-- the address portion and the chain portion should be resolved separately 
-- checksums are MANDATORY
-- checksum hash goes over the entire address, so users can't just replace a component and expect it to stay valid
+## Concepts
 
+Interoperable Address
+: A binary payload which unambiguously identifies a target address and, optionally, a _resolver specification_ which, along with this (and potentially future) ERCs, allows conversion to a human-readable name without requiring further trust assumptions by wallet software.
 
-## Specification
+Human-readable name
+: A string representation of an interoperable address, meant to be used by humans.
 
+Target address
+: The (address, chain ID) pair a particular Interoperable Address points to.
+
+Name-resolving contract
+: A contract responsible for converting addresses and/or chain IDs from a machine-readable format into parts of a human-readable name.
+
+## Out of scope concerns
+Similarly to CAIP-10, this specification is not concerned with the mapping from a chain ID to a network name, which might not be surjective (eg: the case where if there are multiple EIP-155 chains with chain ID 8453, which one should we call Base?), regarding that resolution a social-layer problem until a future ERC decides to tackle it. Efforts in that front are tracked in [the chain registries document](../docs/chain-registries.md)
+
+## Guarantees provided by the standard
+- Any Interoperable Address is trivially convertible to Interoperable Canonical Format (specified below), making it a canonical representation for users who need to treat them opaquely.
+- Checksums are short enough to be compared by humans, and effectively identify a _target address_ independently of any extra data the address may contain.
+
+## General specification
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119 and RFC 8174.
 
-### Format
-
-Valid addresses MUST include the identifier of the chain they belong to.
-
+### Binary format definition
+Word 0 Is the only word which will be common to all versions, and is defined as follows:
 ```
-L1-TLD ::= eth | sepolia | …
-chain_id ::= 0x[a-fA-F0-9]{1,64}
-address ::= 0x[a-fA-F0-9]{40}
-chain ::= <chain_id> | <L1-TLD> | <ens-name> . <L1-TLD>
-user ::= <address> | <ens-subdomain>
-account ::= <user>@<chain>
+MSB                                                            LSB
+0xXXXXYYYYYYYYZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                \------------- 207-0   Reserved
 ```
 
-Note the difference between `ens-name`, which is a full ENS name, and `ens-subdomain` that is just a segment of a name between dots. E.g. `user.app.eth` is a name, `user` and `app` are subdomains.
+No length restriction is placed on how many more words can an Interoperable Address span. Different versions of the standard can define uses for extra words and the 208 reserved bits.
 
-A few examples below. 
+#### Restrictions for all Interoperable Address versions
+- The Interoperable Address MUST include an address and specify the chain it belongs to, fully defining a target address. Any version that adds an indirection layer between payload data and these two fields would violate this restriction.
+- Interoperable Address versions MAY only be able to represent a subset of the CAIP-2 namespaces.
+- Interoperable Address versions MAY define extra fields containing information on how to display the addresses.
+- The most significant version bit is reserved to mean an address complies with the Interoperable Canonical Format, described in Interoperable Address version `0x8000`.
+- The second-most significant version bit is reserved to mean the payload includes information on how to display the address to users, but is not normative about how that information is to be encoded. An example of this is provided in Interoperable Address version `0xC000`.
 
-Option 1: using @ to separate address and chain
-```
-Mainnet
-- 0x12345...6789@0x1
-- 0x12345...6789@eth
-- alice.eth@eth
+### Human-readable name format definition
 
-Testnet (Sepolia)
-- 0x12345...6789@0xaa36a7
-- 0x12345...6789@sepolia
-- alice.eth@sepolia
-
-Rollup
-- 0x12345...6789@chainId
-- 0x12345...6789@arbitrum.eth
-- alice.eth@arbitrum.eth
-
-Rollup Sepolia
-- 0x12345...6789@arbitrum.sepolia
-
-My ENS name is registered on rollup1, but I want to receive funds on rollup2
-- alice.rollup1.eth@rollup2.eth
+#### Syntax
+```bnf
+<human readable name> ::= <account>@<chain>#<checksum>
+<account>             ::= [-:_%a-zA-Z0-9]*
+<chain>               ::= [-:_a-zA-Z0-9]*
+<checksum>            ::= [0-9A-F]{8}
 ```
 
-Option 2: using : instead of @ 
+#### Rationale
+- Chain and account fields' syntax is deliberately chosen to be able to express CAIP-2 namespaces (by using the `@` symbol for the separator, freeing up `:`) and CAIP-10 account IDs, with the caveat that no length restriction is placed, so chains with longer address formats or full 256-bit EVM chainids can be represented.
+- Similarly, the account field includes `%` as a valid character to allow for url-encoding of any other characters.
+
+## Interoperable Address version definitions
+
+### `0x8000`: Interoperable Canonical Format: arbitrary length addresses, CAIP-10 compatible display format
+
+#### Machine-address format
+
+##### First word
+No reserved bits are used. They MUST be set to zero, to ensure canonicity of addresses.
 ```
-Mainnet
-- 0x12345...6789:0x1
-- 0x12345...6789:eth
-- alice.eth:eth
-
-Testnet (Sepolia)
-- 0x12345...6789:0xaa36a7
-- 0x12345...6789:sepolia
-- alice.eth:sepolia
-
-Rollup
-- 0x12345...6789:chainId
-- 0x12345...6789:arbitrum.eth
-- alice.eth:arbitrum.eth
-
-Rollup Sepolia
-- 0x12345...6789:arbitrum.sepolia
-
-My ENS name is registered on rollup1, but I want to receive funds on rollup2
-- alice.rollup1.eth:rollup2.eth
-```
-### CHECKSUM
-<!-- TODO: add more explanation here -->
-
-Two desired properties:
-1) checksums are MANDATORY
-2) checksum hash goes over the entire address, so users can't just go and replace a component and expect it to stay valid
-
-
-### A special case for ENS resolution
-
-Any ENS name today can be resolved to a chain identifier or to an address.
-We could imagine having a name `user.eth` that points to a record of the form `{address ; chain_id}`. Given such an address a wallet can verify it resolves to a valid account.
-The advantage of this format is that it is very flexible and can accommodate a number of use cases, however it can also lead to confusion for users because a name does not necessarily resolve to a valid account. The same `user.eth` could lead to a website, a NFT or multiple addresses.
-
-The resolution of a `address@chain` on the contrary, imposes that the left-hand resolves to an address and the right-hand to a chain identifier.
-
-When given a `user@rollup.eth`, the wallet can resolve `rollup.eth` to get a chain identifier and `user.rollup.eth` to get an address. In any other case it fails.
-
-### L2 resolution
-
-In case an address is not registered on L1, but only on a L2, the resolution can be processed using [ERC-3668](./eip-3668.md) and [ERC-2544](./eip-2544.md)'s  Wildcard Resolution.
-
-In the previous example `user@rollup.eth`, `user` would not be registered on L1.
-In this case the wallet can resolve `rollup.eth` to get a chain identifier as before and when attempting to resolve `user.rollup.eth` to get an address, it would fail and be redirected to the L2 gateway. Any answer from the gateway needs to be verified as explained in the EIP.
-
-#### Note: avoiding the http gateway
-
-In order to avoid contacting an external http gateway, we could define the gateway to be a ENS contract on the L2. In this way a wallet operator would need to only rely on a node following the L1 and a node following the L2.
-
-### L1 resolution
-
-Ethereum Mainnet and its testnets can be resolved to their corresponding chain identifiers using a centralized list, which remains unchanged from how it works today. Other L1 registrations are out of scope for this EIP.
-
-Mapping:
-```
-L1-TLD -> {L1_chain_id : chain_id; L1_ens_address : address;}
-```
-Example:
-```
-eth     -> {L1_chain_id : 0x1;      L1_ens_address : <ENS-address-on-mainnet>}
-sepolia -> {L1_chain_id : 0xaa36a7; L1_ens_address : <ENS-address-on-sepolia>}
+MSB                                                            LSB
+0x8000XXXXXXXX0000000000000000000000000000000000000000000000000000
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              \--------------- 207-0   Reserved
 ```
 
-### Note: clashes of L1 and TLD
+##### Second field
+Serializes the chain ID as described in [Appendix A](#appendix-a-binary-encoding-of-caip-2-blockchain-id) and encodes it into a byte array as described in [Appendix C](#appendix-c-short-encoding-of-byte-arrays). It is a _field_ and not a _word_, since it may take up more than one word.
 
-In the above proposal the ENS TLD and chain name coincide which may be confusing or incorrect in some cases. A more explicit approach could be to have an additional suffix for the chain name.
-Example:
+##### Third field
+Serializes the address as described in [Appendix A](#appendix-a-binary-encoding-of-caip-2-blockchain-id) and encodes it into a byte array as described in [Appendix C](#appendix-c-short-encoding-of-byte-arrays). It is a _field_ and not a _word_, since it may take up more than one word, and may not start at the third word boundary if the second field takes up more than one word.
+
+#### Human-readable name resolution
+The CAIP-2 namespace is to be rendered alongside the CAIP-10 formatted address and the checksum:
+
 ```
-name.eth.mainnet -> {L1_chain_id : 0x1;      L1_ens_address : <ENS-address-on-mainnet>}
-name.eth.sepolia -> {L1_chain_id : 0xaa36a7; L1_ens_address : <ENS-address-on-sepolia>}
-```
-### Note: default fallbacks
-
-If a user receives a legacy address without chain name, the wallet can:
-Refuse the address (safest)
-Default to Mainnet (unambiguous)
-Dynamically default to same chainID as sender (ambiguous and context-dependent but probably compatible with current use-cases)
-
-### Advanced patterns
-
-The `@` syntax described in this EIP is a restricted resolution case for ENS names whose main purpose it to be user-friendly. We can however support more advanced pattern in ENS.
-
-### Supported today
-
-For example a user might configure its name with multiple address such as
-```
-rollup1.user.eth -> {address : address; chain_id : chain_id} 
-rollup2.user.eth -> {address : address; chain_id : chain_id} 
-```
-Given `user.eth` as recipient a wallet could prompt the user to select a destination chain.
-Otherwise the user can be more explicit and give as recipient `rollup1.user.eth`.
-
-### Note: Speculative
-
-Alternatively we could store multiple addressed under the same domain as
-```
-user.eth -> { rollup1 : address * chain_id ; 
-              rollup2 : address * chain_id } 
-```
-if a syntax to access ENS records could be standardized, the user could be asked to be paid at
-`user.eth/rollup1`
-
-### URL compatibility
-
-It would be very desirable to maintain compatibility with the syntax defined by the [Uniform Resource Identifier](https://www.rfc-editor.org/rfc/rfc3986) standard, so that in the future a schema could be supported.
-
-Example of a link to require a payment of 10 tokens to the `user` address living in `rollup`:
-```
-evm://user@rollup.eth.mainnet/transfer?amount=10
+<CAIP-10 formatted address>@<CAIP-2 namespace>#<checksum>
 ```
 
-### Resolution step-by-step example
+#### Examples
 
-1. Check the type of `chain`
-   - if typeof(chain) == “ENS name”: go to step 2
-   - if typeof(chain) == “L1 TLD”: go to step 3
-   - if typeof(chain) == “chainId”: go to step 4
-2. Resolve the ENS name's `text(chainENSName, ‘chain_id’)` record using [ERC-2544](./eip-2544.md) and skip to step 4
-3. Use an offline mapping of `TLD => chainId` to find the relevant chainId.
-4. Check if `account` is an ENS name, if not end the resolution process.
-5. Generate the cointype using the chainId via ENSIP-11: `coinType = 0x80000000 | chainId`
-6. Verify the bridge address by resolving `[chainId].id.eth`'s `name(name, 60)` record using [ERC-2544](./eip-2544.md)
-7. Check if this name matches the ENS name representing the chain, continue otherwise consider the resolution a failure and error.
-8. Resolve the ENS name's `addr(name, cointype)`
+Human-readable name:
+`0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045#6164DA10@eip155:1#618AD0D1`:
 
-## Rationale
+First word:
+```
+MSB                                                            LSB
+0x80006164DA100000000000000000000000000000000000000000000000000000
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              \--------------- 207-0   Not used
+```
 
-#### Using @ vs : for the separator 
+Second word (second field):
+```
+MSB                                                            LSB
+0x0100000000000000000000000000000000000000000000000000000000000002
+  ^^----------------------------------------------------------------- 255-249 bytes array payload
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---- 9-249   padding
+                                                                ^^ -- 0-8    2*1 (payload length)
+```
 
-The colon (`:`) may be a reasonable choice for separator because it is not an allowed character in ENS names, it is familiar (eg. IPv6), and isn't as overloaded as the `@` symbol.
+Third word (third field):
+```
+MSB                                                            LSB
+0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045000000000000000000000028
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------------------------- 255-97 bytes array payload
+                                          ^^^^^^^^^^^^^^^^^^^^^^ ---- 9-96   padding
+                                                                ^^ -- 0-8    2*20 (payload length)
+```
 
-The `@` symbol may be a reasonable choice as it is arguably more human-readable, is already a common choice for addresses, and finds use in email and several federated communication protocols. The English reading (foo-**AT**-example-DOT-com) is natural and implies a hierarchy between the left and the right components.
+<!-- TODO: example with multi-word fields -->
 
-## Backwards Compatibility
+### `0xC000`: Interoperable Canonical Format With Resolver Info: arbitrary length addresses, arbitrary length name-resolving contract specification
 
-No backward compatibility issues found.
+#### Machine-address format
 
-## Security Considerations
+##### First word
+Uses reserved bits as a registry of interfaces the provided resolver conforms to.
+```
+MSB                                                            LSB
+0xC000XXXXXXXX0000000000000000000000000000000000000000000000000000
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              \--------------- 207-0   Resolver Interface Key
+```
+The Resolver Interface Key defines how wallets should interact with the smart contract responsible for assigning names to addresses.
+Said contract MAY also be responsible for naming the chain on which the target address resides as well as providing a human-readable name for the address, when ERC-7785 or similar standards reach production.
 
-<!-- TODO -->
+##### Second field
+Serializes the chain ID of the target address  as described in [Appendix A](#appendix-a-binary-encoding-of-caip-2-blockchain-id) and encodes it into a byte array as described in [Appendix C](#appendix-c-short-encoding-of-byte-arrays).
+
+##### Third field
+Serializes the address of the target address as described in [Appendix A](#appendix-a-binary-encoding-of-caip-2-blockchain-id) and encodes it into a byte array as described in [Appendix C](#appendix-c-short-encoding-of-byte-arrays).
+
+##### Fourth field
+Serializes the chain ID where the name-resolving contract is located as described in [Appendix A](#appendix-a-binary-encoding-of-caip-2-blockchain-id) and encodes it into a byte array as described in [Appendix C](#appendix-c-short-encoding-of-byte-arrays).
+
+##### Fifth field
+Serializes the address of the name-resolving contract as described in [Appendix A](#appendix-a-binary-encoding-of-caip-2-blockchain-id) and encodes it into a byte array as described in [Appendix C](#appendix-c-short-encoding-of-byte-arrays).
+
+#### Human-readable name resolution
+Specific to every Resolver Interface Key
+
+#### Resolver Interface Keys
+
+##### `0x0000000000000000000000000000000000000000000000000000`
+Responsibility over discovering the interface of the naming smart contract is delegated to the contract itself, via mechanisms comparable to `ERC165`, out of scope for this definition.
+
+##### `0x0000000000000000000000000000000000000000000000000001`
+Naming contract is expected to conform to ENSIP-11, and used to display the address. ENSIP-11 does not name chains, so the CAIP-2 name should be used instead.
+
+#### Examples
+
+Human-readable name:
+`vitalik.eth@eip155:1#618AD0D1`:
+
+First word: metadata
+```
+MSB                                                            LSB
+0xC0006164DA100000000000000000000000000000000000000000000000000001
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+              \--------------- 207-0   Resolver Interface Key
+```
+
+Second word (second field): target address' chain ID
+```
+MSB                                                            LSB
+0x000001000000000000000000000000000000000000000000000000000000000C
+  ^^^^^^------------------------------------------------------------- 255-208 bytes array payload
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---- 9-207   padding
+                                                                ^^ -- 0-8     2*6 (payload length)
+```
+
+Third word (third field): target address
+```
+MSB                                                            LSB
+0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045000000000000000000000028
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------------------------- 255-97 bytes array payload
+                                          ^^^^^^^^^^^^^^^^^^^^^^ ---- 9-96   padding
+                                                                ^^ -- 0-8    2*20 (payload length)
+```
+
+Fourth word (fourth field): name resolving contract's chain ID
+```
+MSB                                                            LSB
+0x000001000000000000000000000000000000000000000000000000000000000C
+  ^^^^^^------------------------------------------------------------- 255-208 bytes array payload
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ ---- 9-207   padding
+                                                                ^^ -- 0-8     2*6 (payload length)
+```
+
+Fifth word (fifth field): name resolving contract's address
+```
+MSB                                                            LSB
+0x00000000000C2E074EC69A0DFB2997BA6C7D2E1E000000000000000000000028
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  ------------------------- 255-97 bytes array payload
+                                          ^^^^^^^^^^^^^^^^^^^^^^ ---- 9-96   padding
+                                                                ^^ -- 0-8    2*20 (payload length)
+```
+
+<!-- TODO: example with other ENSIP-11 contract -->
+
+#### Security considerations
+- Wallets will have to maintain a list of Resolver Interface Keys they support, and which name-resolving contracts they consider trustworthy, and display addresses as described in `0x8000` when the provided name-resolving contract is not contained in the list. Said list MAY be updateable by the user.
+
+### `0x0000` : single-word 48-bit EVM chain IDs, no human-readable name resolution
+This encoding is meant to be the shortest possible way to encode most EVM addresses
+
+#### Supported chains
+EVM chains with a chain ID shorter than 48 bits (which potentially rules out chain IDs chosen to comply with ERC-7785)
+
+#### Machine-address format
+
+```
+MSB                                                            LSB
+0x0000000000000000000000000000000000000000000000000000000000000000
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^
+                \------------- 207-160 Chain ID
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            \- 159-0   Address
+```
+
+`Interoperable Address version`
+: Always `0x0000`
+
+`Checksum`
+: Computed as described in [Appendix D](#appendix-d-checksum-computation)
+
+`ChainID`
+: `uint48` containing the chain ID for the target chain
+
+`Address`
+: Native EVM address
+
+#### Human-readable name resolution
+The CAIP-2 namespace is to be rendered alongside the `0x`-prefixed EIP-55 address and the checksum
+
+```
+<address>@<CAIP-2 namespace>#<checksum>
+```
+
+#### Examples:
+Machine address
+: 
+```
+MSB                                                            LSB
+0x0000618AD0D1000000000001D8DA6BF26964AF9D7EED9E03E53415D37AA96045
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^
+                \------------- 207-160 chain ID
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            \- 159-0   Address
+```
+
+Human-readable name
+: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045#6164da10@eip155:1#618AD0D1`
+
+### `0x0001` : Compact format, ENSIP-11+ERC-3770 name resolution 
+The binary representation is identical to the format above, with the exception that the version number is different, indicating the intent for the chain to be displayed using the ERC-3770 shortname and the address to be displayed following mainnet's ENS deployment and ENSIP-11
+
+#### Supported chains
+Chain must be listed on ethereum-lists/chains on top of the restrictions of `0x0000`.
+
+#### Machine-address format
+Same as `0x0000`, with `0x0001` version
+
+#### Examples:
+Machine address
+: 
+```
+MSB                                                            LSB
+0x0001618AD0D1000000000001D8DA6BF26964AF9D7EED9E03E53415D37AA96045
+  ^^^^------------------------ 255-240 Interoperable Address version
+      ^^^^^^^^ --------------- 239-208 Checksum
+              ^^^^^^^^^^^^
+                \------------- 207-160 chain ID
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                            \- 159-0   Address
+```
+
+Human-readable name
+: `vitalik.eth@eth#618AD0D1`
+
+<!-- TODO: example on another chain -->
+
+## Requirements for wallet software
+- Wallet software MUST perform all relevant pre-validations, including verifying the checksum, and report any errors to the user.
+- Wallets MAY reject an interoperable address solely on the basis of the checks above failing.
+
+## Encoding considerations
+- On-chain actors, such as smart contracts, MUST always receive and return the machine addresses as byte array.
+- On-chain actors, such as smart contracts, MAY only accept canonical `0x8000` address versions, with off-chain actors being responsible over converting them to said format.
+- Off-chain actors, such as wallets, MAY use the blockchain-native byte array representation, or, where practical MAY alternatively use base64 [^2] as defined in RFC-4648 to encode the former.
+- Users SHOULD NOT be shown the base64 or binary representations. Instead, they should be presented with the intended human-readable name or, in cases where that is not possible, wallet software MUST fall back to interpreting it as an Interoperable Address version `0x8000`.
+
+[^2]: Base64 was chosen since it is a more widely implemented standard than base58. Additionally, since machine addresses are not to be directly displayed to the user, the collision-avoidance reasons in favor of base58 do not apply
+
+## Appendix A: Binary encoding of CAIP-2 blockchain ID
+The first two bytes are the binary representation of CAIP-2 namespace (see table below), while the remaining bytes correspond to the CAIP-2 reference, whose encoding is namespace-specific and defined below.
+
+### CAIP-2 namespaces' binary representation table
+
+| Namespace | binary key |
+| ---       | ---        |
+| eip155    | `0x0000`   |
+| bip122    | `0x0001`   |
+
+#### eip155
+The bare `chainid` encoded as a `uint` of the necessary amount of bytes will be used [^1]. This allows for most of existing EVM chain IDs to fit inside one EVM word.
+
+[^1]: This makes it possible to represent some chains using the full word as their chainid, which CAIP-2 does not support since the set of values representable with 32 `a-zA-Z0-9` characters has less than `type(uint256).max` elements. This is done in an effort to support chains whose ID is the output of `keccak256`, as proposed in ERC-7785.
+
+##### Examples
+Ethereum Mainnet: `0x000001` (1, encoded as uint8)
+
+Optimism Mainnet: `0x00000A` (10, encoded as uint8)
+
+Ethereum Sepolia: `0x0000aa36a7` (11155111, encoded as uint24)
+
+#### bip122
+The genesis/fork blockhash is to be stored raw, without encoding/decoding from/to base58btc, and without removing any leading zeroes:
+
+Note: CAIP-2 limits chain references to 32 characters, so converting to it will require truncating the reference, so converting _from_ CAIP-2 to this standard is potentially ambiguous (but converting from actual bip122 to this standard will never be).
+
+##### Examples
+Bitcoin Mainnet
+: `0x0001000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f`
+
+Litecoin
+: `0x000112a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2`
+
+## Appendix B: Binary encoding of addresses
+
+### eip155
+20 bytes of evm addresses trivially stored as the payload.
+
+#### Examples
+`0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045` -> `0xD8DA6BF26964AF9D7EED9E03E53415D37AA96045`
+
+### solana
+base-58 encoded public keys should be decoded and stored as a 32 byte payload
+
+#### Examples
+
+`7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv` -> `0x5F90554BB3D8C2FC82B6EE59C49AAA143E77F7D49A83E956CE1DBEF17A43F805`
+
+`DYw8jCTfwHNRJhhmFcbXvVDTqWMEVFBX6ZKUmG5CNSKK` -> `0xBA7A74F374AB05B70D114A78112EF0D3F0695A819572C79710B5372000D81AE2`
+
+## Appendix C: Short-encoding of byte arrays
+This is a mix between [how bytes and strings are saved into storage](https://docs.soliditylang.org/en/latest/internals/layout_in_storage.html#bytes-and-string) and how ABI encoding works
+
+This arises out of:
+- The need for the shortest possible representation of EVM addresses.
+- The absence of a canonical place to delimit the _start_ of the data (in the case of storage strings, this is the keccak256 hash of the storage slot index).
+
+If the data is at most 31 bytes long, the elements are stored in the higher-order bytes (left-aligned) and the lowest-order byte stores the value `length * 2`.
+
+If the data is 32 bytes or longer, the current word stores `length * 2 + 1`, and data follows in the next words, left-aligned and zero-padded.
+
+This means access to an arbitrary field in the structure requires a worst-case linear amount of reads. Future encodings using it should take it into consideration to put less-frequently-accessed members last.
+
+### Examples 
+
+`0x1234`: `0x1234000000000000000000000000000000000000000000000000000000000005`
+
+`0x01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF1234`: `0x01FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF12343E`
+
+`0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF`:
+```
+0x
+0000000000000000000000000000000000000000000000000000000000000041
+00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF
+```
+
+`0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF0011`:
+```
+0x
+0000000000000000000000000000000000000000000000000000000000000045
+00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF
+0011000000000000000000000000000000000000000000000000000000000000
+```
+
+### Rationale
+With this approach, packing the data right after the word saving its length instead of storing the offset to the data, we don't allow for extra information to be inserted in a way that is not visible to parsers (as is possible with ABI encoding), which allows for the canonicity of encoded addresses.
+
+## Appendix D: checksum computation
+With the intent of:
+- Maximizing the difficulty of mining checksum collisions
+- Maximize the safety a user gets from knowing the checksum matches
+- Allow maximum flexibility for human-readable names, leveraging the above to make human-readable name collisions permissible.
+
+And considering:
+- Binary payloads will often have their own error-correction mechanisms when in transit (eg: if encoded into a QR code, said QR code will have information redundancy & its own checksum ensuring only valid data can be decoded), so that can safely be deemed out of scope.
+<!-- TODO: Considering the above, does it make sense to store the checksum inside the address? -->
+
+We propose a way to serialize the 'abstract' components of an address, ignoring the information on how it should be displayed, to achieve the above: 
+
+```solidity
+    function getChecksum(bytes2 caip2Namespace, bytes memory chainId, bytes memory address_)
+        internal
+        view
+        returns (bytes4 checksum)
+    {
+        bytes memory fullChainId = bytes.concat(caip2Namespace, chainId);
+        // Deliberately abi-encode instead of encode-packed to avoid preimage collisions
+        bytes memory serialized = abi.encode(fullChainId, address_);
+        bytes32 hashed = keccak256(serialized);
+        checksum = bytes4(hashed);
+    }
+```
+<!-- TODO: describe this in a way which is not potentially coupled to solidity (or even a specific version of it) -->
 
 ## Copyright
-
 Copyright and related rights waived via [CC0](../LICENSE.md).


### PR DESCRIPTION
This PR aims to rewrite ERC-7828 to use a versioned and binary-first payload format, as discussed on calls on March 10 and 19. 

This backports the work on the [L2 interop](https://github.com/ethereum/L2-interop) repository to the ERC-7828 standard, with the intention of moving forwards in the ERC lifecycle in the near future.

We propose for discussion on this PR to focus on whether this is a faithful representation of the work done on ethereum/L2-interop in ERC format, and focusing discussion on the standard itself either in the PR from jrudolf/ERCs -> ethereum/ERCs or the ethereum magician's' thread.

Intended review checks:
- [ ] This does not miss any of the content present in ethereum/L2-interop (recommendation: compare this working tree vs the document on the aforementioned repository)
- [ ] This does not delete any section or explaination present in the previous iteration of ERC-7828 without defining an equivalent section/explaination. (recommendation: review the diff as presented in github)
